### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ To uninstall
 Prerequisites
 -------------
 byacc or yacc
+
 flex
+
 Fortran and C compiler
+
 Python

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Disclaimer
 While this package is derived from the AmberTools source code (see
 http://ambermd.org), it is *NOT* supported or maintained by the Amber community.
 
-If you need support or plan to use the tools here directly, you are recommended
+If you need support or plan to use these tools directly, you are recommended
 to use the official release of AmberTools.
 
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,43 @@
 ambermini
 =========
 
-A stripped-down set of just antechamber, sqm, and tleap.
+A stripped-down set of just antechamber, sqm, and tleap. This package exists
+specifically to provide a lightweight subset of the AmberTools installation so
+that they can be installed as dependencies of other programs.
 
+Unless you know what you are doing (and do not need support from the Amber
+community), you should download and use the full AmberTools suite available at
+http://ambermd.org.
 
-To install
+Disclaimer
 ==========
 
-./configure --prefix <destination>
+While this package is derived from the AmberTools source code (see
+http://ambermd.org), it is *NOT* supported or maintained by the Amber community.
+
+If you need support or plan to use the tools here directly, you are recommended
+to use the official release of AmberTools.
+
+
+For Developers
+==============
+
+To install
+----------
+
+`./configure --prefix <destination>`
 make
 make install
 
 
 To uninstall
-============
+------------
 
-make uninstall
+`make uninstall`
 
 
 Prerequisites
-=============
+-------------
 byacc or yacc
 flex
 Fortran and C compiler

--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ For Developers
 To install
 ----------
 
-`./configure --prefix <destination>`
+```
+./configure --prefix <destination>
 make
 make install
+```
 
 
 To uninstall

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To uninstall
 
 Prerequisites
 -------------
-byacc or yacc
+byacc, yacc, or bison
 
 flex
 


### PR DESCRIPTION
Try to put in big, bold font that ambermini is _not_ an AmberTools replacement and is primarily aimed at satisfying dependencies for other programs.