### PR TITLE
Link sqm with CC

### DIFF
--- a/sqm/Makefile
+++ b/sqm/Makefile
@@ -82,8 +82,8 @@ install: sqm$(SFX)
 	mv sqm$(SFX) $(BINDIR)
 
 sqm$(SFX): $(SQMOBJ) $(QMOBJ) sys
-	$(FC) $(FPPFLAGS) $(FFLAGS) $(AMBERFFLAGS) -o sqm$(SFX) $(SQMOBJ) $(QMOBJ) \
-		$(FLIBSF) ../lib/sys.a $(LDFLAGS) $(AMBERLDFLAGS)
+	$(CC) $(FPPFLAGS) $(FFLAGS) $(AMBERFFLAGS) -o sqm$(SFX) $(SQMOBJ) $(QMOBJ) \
+		$(FLIBS) ../lib/sys.a $(LDFLAGS) $(AMBERLDFLAGS)
 
 #-----------LIBS
 


### PR DESCRIPTION
Linking the final sqm binary with $(CC) instead of $(FC) makes it possible to build binaries that don't have a runtime dependency on libgfortran (by passing the proper static libraries through LDFLAGS).