### PR TITLE
Separate source comment from numeric value of c1-sh-hs in gaff.dat

### DIFF
--- a/share/amber/dat/leap/parm/gaff.dat
+++ b/share/amber/dat/leap/parm/gaff.dat
@@ -4753,7 +4753,7 @@ sh-s6-ss   60.36      102.64                  SOURCE3         1
 s -s6-s    60.63      109.34                  SOURCE3         1          
 ss-s6-ss   60.46      101.82                  SOURCE3         1          
 br-sh-hs   43.57       95.64                  SOURCE3         1          
-c1-sh-hs   48.14       95.99calculated_based_on_C#C-SH         0          
+c1-sh-hs   48.14       95.99 calculated_based_on_C#C-SH       0          
 c2-sh-hs   45.72       96.79          SOURCE4_SOURCE5        12    0.5703
 c3-sh-hs   44.49       96.40          SOURCE3_SOURCE5       191    0.6428
 ca-sh-hs   46.05       95.50          SOURCE4_SOURCE5        44    0.8350


### PR DESCRIPTION
In current `gaff.dat`, source comments are right aligned (introduced in [this commit](https://github.com/choderalab/ambermini/compare/15.0.4...master#diff-f8dfba552f0978cafb7072b154e04bf8), I think). In line `4756`, this resulted in the source comment (longer than usual) sticking to the numeric value on its left. This causes parsing errors in some libraries, such as `openmoltools`:

```
File "/home/jaimergp/.local/anaconda/envs/openmm/lib/python3.5/site-packages/openmoltools/utils.py", line 211, in create_ffxml_file
    ffxml_stream = parser.generate_xml()
  File "/home/jrodriguez/.local/anaconda/envs/openmm/lib/python3.5/site-packages/openmoltools/amber_parser.py", line 392, in generate_xml
    theta = float(angle[4]) * math.pi / 180.0
ValueError: could not convert string to float: '95.99calculated_based_on_C#C-SH'
```

I just added a space between the number  and the source comment and seems to work, but as a result that row is no longer right aligned. Maybe you want to add additional spaces to the whole section so that line doesn't stick out (OCD issues here), but I was reticent to commit such a huge number of lines for a trivial problem.